### PR TITLE
feat: add Image  component

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,6 +2,7 @@ import type { StorybookConfig } from '@storybook/nextjs';
 
 const config: StorybookConfig = {
   stories: ['../components/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  staticDirs: ['../public'],
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-essentials',

--- a/components/content/Card.stories.tsx
+++ b/components/content/Card.stories.tsx
@@ -1,22 +1,58 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
 
 import Card from './Card';
 
-const meta: Meta<typeof Card> = {
-  component: Card,
+export default {
+  title: 'Components/Card',
   tags: ['autodocs'],
+  component: Card,
 };
 
-export default meta;
+export const Default = () => (
+  <Card>
+    <Card.Heading>Default Card</Card.Heading>
+    <Card.Text>This is a default card with heading and text.</Card.Text>
+  </Card>
+);
 
-type Story = StoryObj<typeof Card>;
+export const WithImage = () => (
+  <Card>
+    <Card.Heading>Card with Image</Card.Heading>
+    <Card.Text>This card includes an image.</Card.Text>
+    <Card.Image
+      src="https://placebeard.it/g/400/300"
+      alt="An example image"
+      width={400}
+      height={300}
+    />
+  </Card>
+);
 
-export const Primary: Story = {
-  args: {},
-  render: () => (
-    <Card>
-      <Card.Heading>Really nice card</Card.Heading>
-      <Card.Text>Some really nice words. Should not be too long, I think</Card.Text>
-    </Card>
-  ),
-};
+export const MultipleTexts = () => (
+  <Card>
+    <Card.Heading>Card with Multiple Texts</Card.Heading>
+    <Card.Text>Text 1: Short description.</Card.Text>
+    <Card.Text>Text 2: Another short description.</Card.Text>
+  </Card>
+);
+
+export const ComplexCard = () => (
+  <Card>
+    <Card.Heading>Complex Card</Card.Heading>
+    <Card.Text>This card includes various elements.</Card.Text>
+    <Card.Image
+      src="https://placebeard.it/g/600/300"
+      alt="An example image"
+      width={600}
+      height={200}
+    />
+    <Card.Text>Additional text below the image.</Card.Text>
+  </Card>
+);
+
+export const CustomClasses = () => (
+  <Card>
+    <Card.Heading className="bg-teal-200">Custom Styling</Card.Heading>
+    <Card.Text className="text-red-500">This card has custom styling applied.</Card.Text>
+  </Card>
+);

--- a/components/content/Card.tsx
+++ b/components/content/Card.tsx
@@ -1,15 +1,21 @@
 import { default as NextImage } from 'next/image';
 import React, { ReactNode } from 'react';
 
+import { default as HeadingComponent } from './Heading';
+
 interface CardChildProps {
   type?: 'Heading' | 'Text' | 'Image';
-  children: ReactNode;
   className?: string;
 }
 
-interface HeadingProps extends CardChildProps {}
+interface HeadingProps extends CardChildProps {
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  children: ReactNode;
+}
 
-interface TextProps extends CardChildProps {}
+interface TextProps extends CardChildProps {
+  children: ReactNode;
+}
 
 interface ImageProps extends CardChildProps {
   src: string;
@@ -32,15 +38,15 @@ const Card = (props: CardProps) => {
   });
 
   return (
-    <div className="max-w-md p-3 bg-white border border-gray-200 rounded-md shadow dark:bg-gray-800 dark:border-gray-700">
+    <div className="max-w-md p-3 bg-white border border-gray-200 rounded-md shadow text-gray-800 dark:text-gray-200 dark:bg-gray-900 dark:border-gray-700">
       {renderedChildren}
     </div>
   );
 };
 
 // Heading component
-const Heading: React.FC<HeadingProps> = ({ children }) => (
-  <h4 className="mb-2 text-2xl font-bold tracking-tight">{children}</h4>
+const Heading: React.FC<HeadingProps> = ({ as = 'h4', children }) => (
+  <HeadingComponent as={as}>{children}</HeadingComponent>
 );
 
 // Text component

--- a/components/content/Card.tsx
+++ b/components/content/Card.tsx
@@ -1,41 +1,65 @@
+import { default as NextImage } from 'next/image';
 import React, { ReactNode } from 'react';
+
+interface CardChildProps {
+  type?: 'Heading' | 'Text' | 'Image';
+  children: ReactNode;
+  className?: string;
+}
+
+interface HeadingProps extends CardChildProps {}
+
+interface TextProps extends CardChildProps {}
+
+interface ImageProps extends CardChildProps {
+  src: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
 
 interface CardProps {
   children: ReactNode;
 }
 
 const Card = (props: CardProps) => {
-  // Loop through the children and render them based on their types
+  // Filter out and render only valid child elements
   const renderedChildren = React.Children.map(props.children, child => {
-    if (React.isValidElement(child) && (child.type === Card.Heading || child.type === Card.Text)) {
-      return <>{child}</>;
+    if (React.isValidElement<HeadingProps | TextProps | ImageProps>(child)) {
+      return child;
     }
     return null; // Ignore other types of children
   });
 
   return (
-    <div className="max-w-md p-6 bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
+    <div className="max-w-md p-3 bg-white border border-gray-200 rounded-md shadow dark:bg-gray-800 dark:border-gray-700">
       {renderedChildren}
     </div>
   );
 };
 
-interface HeadingProps {
-  children: ReactNode;
-}
+// Heading component
 const Heading: React.FC<HeadingProps> = ({ children }) => (
-  <h4 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-    {children}
-  </h4>
+  <h4 className="mb-2 text-2xl font-bold tracking-tight">{children}</h4>
 );
-Card.Heading = Heading;
 
-interface TextProps {
-  children: ReactNode;
-}
-const Text: React.FC<TextProps> = ({ children }) => (
-  <p className="mb-3 font-normal text-gray-500 dark:text-gray-400">{children}</p>
+// Text component
+const Text: React.FC<TextProps> = ({ children }) => <p className="mb-3 font-normal">{children}</p>;
+
+// Image component
+const Image: React.FC<ImageProps> = props => (
+  <NextImage
+    src={props.src}
+    alt={props.alt ?? ''}
+    width={props.width}
+    height={props.height}
+    className="-px-2"
+  />
 );
+
+// Define valid child types after the components are defined
+Card.Heading = Heading;
 Card.Text = Text;
+Card.Image = Image;
 
 export default Card;

--- a/components/content/Image.stories.tsx
+++ b/components/content/Image.stories.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable jsx-a11y/alt-text */
+import { Meta } from '@storybook/react';
+import React from 'react';
+
+import Image, { ImageProps } from './Image';
+
+function getRandomImageUrl(): { url: string; width: number; height: number } {
+  const width = Math.floor(Math.random() * 1000) + 200;
+  const height = Math.floor(Math.random() * 600) + 200;
+  const url = `https://picsum.photos/${width}/${height}`;
+
+  return { url, width, height };
+}
+
+export default {
+  component: Image,
+  tags: ['autodocs'],
+  argTypes: {
+    src: { control: 'text', description: 'Image URL' },
+    alt: { control: 'text', description: 'Alternative text for the image' },
+    caption: { control: 'text', description: 'Caption for the image' },
+    className: { control: 'text', description: 'CSS classes for custom styling' },
+    width: { control: 'number', description: 'Image width' },
+    height: { control: 'number', description: 'Image height' },
+  },
+} as Meta;
+
+export const DefaultImage = (args: ImageProps) => <Image {...args} />;
+const randomDefaultImage = getRandomImageUrl();
+DefaultImage.args = {
+  src: randomDefaultImage.url,
+  alt: 'A beautiful landscape',
+  caption: 'A breathtaking view of nature',
+  width: randomDefaultImage.width,
+  height: randomDefaultImage.height,
+};
+
+export const ImageWithoutCaption = (args: ImageProps) => <Image {...args} />;
+const randomImageWithoutCaption = getRandomImageUrl();
+ImageWithoutCaption.args = {
+  src: randomImageWithoutCaption.url,
+  alt: 'A cute animal',
+  width: randomImageWithoutCaption.width,
+  height: randomImageWithoutCaption.height,
+};
+
+export const ImageWithCustomDimensions = (args: ImageProps) => <Image {...args} />;
+const randomImageWithCustomDimensions = getRandomImageUrl();
+ImageWithCustomDimensions.args = {
+  src: randomImageWithCustomDimensions.url,
+  alt: 'An artistic masterpiece',
+  caption: 'An inspiring work of art',
+  width: randomImageWithCustomDimensions.width,
+  height: randomImageWithCustomDimensions.height,
+};
+
+export const ImageWithCustomStyling = (args: ImageProps) => <Image {...args} />;
+const randomImageWithCustomStyling = getRandomImageUrl();
+ImageWithCustomStyling.args = {
+  src: randomImageWithCustomStyling.url,
+  alt: 'A stylish fashion shot',
+  caption: 'A glimpse of the latest fashion trends',
+  className: 'border-4 border-pink-500',
+  width: randomImageWithCustomStyling.width,
+  height: randomImageWithCustomStyling.height,
+};

--- a/components/content/Image.tsx
+++ b/components/content/Image.tsx
@@ -4,23 +4,29 @@ export type ImageProps = {
   src: string;
   alt?: string;
   caption?: string | null | undefined;
-  className?: string;
+  imgClassName?: string;
+  figureClassName?: string;
+  figCaptionClassName?: string;
   width?: number;
   height?: number;
 };
 
 const Image = (props: ImageProps) => {
   return (
-    <figure className="max-w-lg py-8">
+    <figure className={props.figureClassName ?? 'max-w-lg py-8'}>
       <NextImage
-        className={props.className ?? 'h-auto max-w-full rounded-lg'}
+        className={props.imgClassName ?? 'h-auto max-w-full'}
         src={props.src}
         alt={props.alt ?? ''}
         width={props.width}
         height={props.height}
       />
       {props.caption && (
-        <figcaption className="mt-2 text-sm text-center text-gray-500 dark:text-gray-400">
+        <figcaption
+          className={
+            props.figCaptionClassName ?? 'mt-2 text-sm text-center text-gray-500 dark:text-gray-400'
+          }
+        >
           <p>{props.caption}</p>
         </figcaption>
       )}

--- a/components/content/Image.tsx
+++ b/components/content/Image.tsx
@@ -1,0 +1,31 @@
+import { default as NextImage } from 'next/image';
+
+export type ImageProps = {
+  src: string;
+  alt?: string;
+  caption?: string | null | undefined;
+  className?: string;
+  width?: number;
+  height?: number;
+};
+
+const Image = (props: ImageProps) => {
+  return (
+    <figure className="max-w-lg py-8">
+      <NextImage
+        className={props.className ?? 'h-auto max-w-full rounded-lg'}
+        src={props.src}
+        alt={props.alt ?? ''}
+        width={props.width}
+        height={props.height}
+      />
+      {props.caption && (
+        <figcaption className="mt-2 text-sm text-center text-gray-500 dark:text-gray-400">
+          <p>{props.caption}</p>
+        </figcaption>
+      )}
+    </figure>
+  );
+};
+
+export default Image;

--- a/components/content/index.ts
+++ b/components/content/index.ts
@@ -2,3 +2,4 @@ export { default as Text } from '../content/Text';
 export { default as Card } from './Card';
 export { default as DataTable } from './DataTable';
 export { default as Heading } from './Heading';
+export { default as Image } from './Image';

--- a/components/inputs/Button.tsx
+++ b/components/inputs/Button.tsx
@@ -13,7 +13,7 @@ const Button = (props: ButtonProps) => {
       disabled={props.disabled}
       aria-label={props.ariaLabel}
       onClick={props.onClick}
-      className="bg-sky-400 dark:bg-sky-950 hover:bg-sky-700 text-white font-bold py-2 px-4"
+      className="bg-sky-400 dark:bg-sky-950 hover:bg-sky-700 text-white font-bold my-6 py-4 px-4"
     >
       {props.leftIcon && <span className="mr-2">{props.leftIcon}</span>}
       {props.children}

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,10 @@ const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ['@losol/eventuras'],
 
+  images: {
+    unoptimized: true,
+  },
+
   i18n: {
     // Disable automatic locale detection and redirect
     localeDetection: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/server": "^11.11.0",
         "@headlessui/react": "^1.7.16",
-        "@losol/eventuras": "^0.3.0",
+        "@losol/eventuras": "^0.3.1",
         "@mantine/core": "^6.0.17",
         "@mantine/dates": "^6.0.17",
         "@mantine/hooks": "^6.0.17",
@@ -3369,9 +3369,9 @@
       "dev": true
     },
     "node_modules/@losol/eventuras": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@losol/eventuras/-/eventuras-0.3.0.tgz",
-      "integrity": "sha512-DF56xb5wnJvzcd/EMb+oricjUUExXdFpvQeSxBl3/1mjuN3abjrm30vdq3pbwexJ1sbKE82V60iQOZRMZvsM2A=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@losol/eventuras/-/eventuras-0.3.1.tgz",
+      "integrity": "sha512-2WfTm08BZhXJClOHrhYDPcMTQ7t916oH3eLht6QUFn08qj891O4bbbnyg4IlBnbqeIDOJahms3SBa9gDnhiwfg=="
     },
     "node_modules/@mantine/core": {
       "version": "6.0.17",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/server": "^11.11.0",
     "@headlessui/react": "^1.7.16",
-    "@losol/eventuras": "^0.3.0",
+    "@losol/eventuras": "^0.3.1",
     "@mantine/core": "^6.0.17",
     "@mantine/dates": "^6.0.17",
     "@mantine/hooks": "^6.0.17",

--- a/pages/events/[id]/index.tsx
+++ b/pages/events/[id]/index.tsx
@@ -5,7 +5,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { Button } from 'components/inputs';
 import { Layout } from 'components/layout';
 import { Modal } from 'components/overlays';
-import { Heading } from 'components/content';
+import { Heading, Image } from 'components/content';
 import parse from 'html-react-parser';
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
@@ -23,6 +23,15 @@ const EventInfo = (props: EventProps) => {
   return (
     <Layout>
       <Heading>{title}</Heading>
+      {props.featuredImageUrl && (
+        <Image
+          src={props.featuredImageUrl}
+          alt=""
+          width={600}
+          height={400}
+          caption={props.featuredImageCaption}
+        />
+      )}
       {description}
       <div>
         <Button onClick={() => router.push(`${props.id}/register`)}>Register for event</Button>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*", "public/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
This commit adds a new component called Image. The Image component is used to display images with optional caption and custom dimensions. It accepts props such as `src`, `alt`, `caption`, `className`, `width`, and `height`.

The commit also includes updates to the `index.ts` file to expose the Image component.

Lastly, the commit adds a placeholder image
 file under the `public/images` directory.