### PR TITLE
feat: a friendlier ui when something goes wrong in event registration

### DIFF
--- a/src/components/feedback/FatalError.tsx
+++ b/src/components/feedback/FatalError.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { BlockLink } from '../inputs/Link';
+const FatalError = ({ title, description }: { title: string; description: string }) => (
+  <div className="fixed w-full h-full top-0 left-0 right-0 bg-black flex p-10">
+    <div
+      className="bg-red-100 w-full border-l-4 border-red-500 text-red-800 p-4 self-center "
+      role="alert"
+    >
+      <p className="font-bold">{title}</p>
+      <p>{description}</p>
+      <BlockLink href="/">Return</BlockLink>
+    </div>
+  </div>
+);
+
+export default FatalError;


### PR DESCRIPTION
Todo: maybe this is the time to have a look at some headless ui, or radix (which I believe @Rados51  was working on) - and see if we can slowly implement it (perhaps from the cherry pick from the experimental branch), before reinventing the wheel on alert popups and toasters etc.