### PR TITLE
feat: Add clientside pagination in AdminEventList

### DIFF
--- a/src/app/admin/AdminEventList.tsx
+++ b/src/app/admin/AdminEventList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { EventDto } from '@losol/eventuras';
+import Link from 'next/link';
 
 import { createColumnHelper, DataTable } from '@/components/content';
 const columnHelper = createColumnHelper<EventDto>();
@@ -8,7 +9,7 @@ const columnHelper = createColumnHelper<EventDto>();
 const columns = [
   columnHelper.accessor('title', {
     header: 'Title',
-    cell: info => info.getValue(),
+    cell: info => <Link href={`/admin/events/${info.row.original.id}`}> {info.getValue()}</Link>,
   }),
   columnHelper.accessor('location', {
     header: 'Location',
@@ -27,7 +28,7 @@ interface AdminEventListProps {
 const AdminEventList: React.FC<AdminEventListProps> = ({ eventinfo = [] }) => {
   return (
     <>
-      <DataTable data={eventinfo} columns={columns} />
+      <DataTable data={eventinfo} columns={columns} clientsidePagination />
     </>
   );
 };

--- a/src/hooks/apiHooks.ts
+++ b/src/hooks/apiHooks.ts
@@ -40,9 +40,15 @@ export const useEvents = (options: GetEventsOptions = {}) => {
   const [response, setResponse] = useState<EventDtoPageResponseDto | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
+  const optionsRef = useRef(options);
+
+  useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
+
   useEffect(() => {
     const execute = async () => {
-      const result = await getEvents(options);
+      const result = await getEvents(optionsRef.current);
       setLoading(false);
       if (result.ok) {
         setResponse(result.value);
@@ -51,7 +57,8 @@ export const useEvents = (options: GetEventsOptions = {}) => {
       setResponse(null);
     };
     execute();
-  }, [options]);
+  }, []);
+
   return { loading, response, events: response?.data };
 };
 


### PR DESCRIPTION
- Adds links from the event list in admin to event details page
- Adds a new prop `clientsidePagination` to the DataTable component in AdminEventList.tsx.
- Updates the DataTable component to handle clientside pagination logic.
- Updates the useEffect hook in apiHooks.ts to use a ref for options as it was re rendering a lot