### PR TITLE
feat: serverside pagination for admin event list

### DIFF
--- a/cypress/support/component-index.html
+++ b/cypress/support/component-index.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <title>Components App</title>
     <!-- Used by Next.js to inject CSS. -->
     <div id="__next_css__DO_NOT_USE__"></div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -7,8 +7,6 @@ import { InputAutoComplete } from '@/components/forms/Input';
 import { Container, Layout } from '@/components/ui';
 import Heading from '@/components/ui/Heading';
 import Link from '@/components/ui/Link';
-import Loading from '@/components/ui/Loading';
-import { useEvents } from '@/hooks/apiHooks';
 import { getUsers } from '@/utils/api/functions/users';
 import Environment from '@/utils/Environment';
 import Logger from '@/utils/Logger';
@@ -22,12 +20,7 @@ const l = { namespace: 'admin' };
 export default function AdminPage() {
   const { t } = useTranslation('admin');
   const { t: common } = useTranslation('common');
-  const { loading: eventsLoading, events } = useEvents({
-    organizationId: ORGANIZATION_ID,
-    includeDraftEvents: true,
-    includePastEvents: true,
-    count: 250,
-  });
+
   return (
     <Layout>
       <Container>
@@ -48,7 +41,7 @@ export default function AdminPage() {
           }}
         />
         <Heading as="h2">{common('events')}</Heading>
-        {eventsLoading ? <Loading /> : <AdminEventList eventinfo={events ?? []} />}
+        <AdminEventList organizationId={ORGANIZATION_ID} />
       </Container>
     </Layout>
   );

--- a/src/components/ui/DataTable.tsx
+++ b/src/components/ui/DataTable.tsx
@@ -1,42 +1,24 @@
 'use client';
 
 import {
-  IconArrowLeft,
-  IconArrowRight,
-  IconChevronsLeft,
-  IconChevronsRight,
-} from '@tabler/icons-react';
-import {
   flexRender,
   getCoreRowModel,
   getPaginationRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
-import Button from '@/components/ui/Button';
-import Text from '@/components/ui/Text';
+import Pagination from './Pagination';
 
 type DataTableProps = {
   columns: any[];
   data: any[];
-  handlePageClick?: (page: number) => void;
-  totalPages?: number;
-  page?: number;
   clientsidePagination?: boolean;
   clientsidePaginationPageSize?: number;
 };
 
 const DataTable = (props: DataTableProps) => {
-  const {
-    columns,
-    data,
-    handlePageClick,
-    totalPages,
-    page,
-    clientsidePagination,
-    clientsidePaginationPageSize = 25,
-  } = props;
+  const { columns, data, clientsidePagination, clientsidePaginationPageSize = 25 } = props;
 
   const handleClientPageChange = (newPage: number) => {
     table.setPageIndex(newPage);
@@ -83,62 +65,15 @@ const DataTable = (props: DataTableProps) => {
       </table>
 
       {clientsidePagination && table.getPageCount() > 1 ? (
-        <Text classname="flex bg-slate-50 py-2 px-5">
-          <Button
-            aria-label="Previous Page"
-            onClick={() => handleClientPageChange(table.getState().pagination.pageIndex - 1)}
-            disabled={!table.getCanPreviousPage()}
-            leftIcon={<IconChevronsLeft />}
-            className="flex-col"
-          />
-          <Text classname="flex-col">
-            Page <Text as="span">{table.getState().pagination.pageIndex + 1}</Text> of{' '}
-            <Text as="span">{table.getPageCount()}</Text>
-          </Text>
-          <Button
-            aria-label="Next Page"
-            onClick={() => handleClientPageChange(table.getState().pagination.pageIndex + 1)}
-            disabled={!table.getCanNextPage()}
-            leftIcon={<IconChevronsRight />}
-            className="flex-col"
-          />
-        </Text>
+        <Pagination
+          currentPage={table.getState().pagination.pageIndex + 1}
+          totalPages={table.getPageCount()}
+          onPreviousPageClick={() =>
+            handleClientPageChange(table.getState().pagination.pageIndex - 1)
+          }
+          onNextPageClick={() => handleClientPageChange(table.getState().pagination.pageIndex + 1)}
+        />
       ) : null}
-
-      {
-        // Server side pagination needs some work...
-        !clientsidePagination && handlePageClick && page && totalPages ? (
-          <Text>
-            <Button
-              ariaLabel="First page"
-              onClick={() => handlePageClick(1)}
-              disabled={page === 1}
-              leftIcon={<IconArrowLeft />}
-            />
-            <Button
-              aria-label="Previous page"
-              onClick={() => handlePageClick(page - 1)}
-              disabled={page - 1 <= 0}
-              leftIcon={<IconChevronsLeft />}
-            />
-            <Text>
-              Page <Text as="span">{page}</Text> of <Text as="span">{totalPages}</Text>
-            </Text>
-            <Button
-              aria-label="Next Page"
-              onClick={() => handlePageClick(page + 1)}
-              disabled={page + 1 > totalPages}
-              leftIcon={<IconChevronsRight />}
-            />
-            <Button
-              aria-label="Last page"
-              onClick={() => handlePageClick(totalPages)}
-              disabled={page === totalPages}
-              leftIcon={<IconArrowRight />}
-            />
-          </Text>
-        ) : null
-      }
     </>
   );
 };

--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -1,0 +1,44 @@
+import { IconChevronsLeft, IconChevronsRight } from '@tabler/icons-react';
+
+import Button from './Button';
+import Text from './Text';
+
+export type PaginationProps = {
+  onPreviousPageClick: () => void;
+  onNextPageClick: () => void;
+  currentPage: number;
+  totalPages: number;
+};
+
+const Pagination: React.FC<PaginationProps> = ({
+  onPreviousPageClick,
+  onNextPageClick,
+  currentPage,
+  totalPages,
+}) => {
+  return (
+    <div className="flex justify-center">
+      <Text className="flex py-2 px-5">
+        <Button
+          aria-label="Previous Page"
+          onClick={onPreviousPageClick}
+          disabled={currentPage <= 1}
+          leftIcon={<IconChevronsLeft />}
+          className="flex-col"
+        />
+        <Text className="flex-col">
+          Page <Text as="span">{currentPage}</Text> of <Text as="span">{totalPages}</Text>
+        </Text>
+        <Button
+          aria-label="Next Page"
+          onClick={onNextPageClick}
+          disabled={currentPage >= totalPages}
+          leftIcon={<IconChevronsRight />}
+          className="flex-col"
+        />
+      </Text>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/components/ui/Text.tsx
+++ b/src/components/ui/Text.tsx
@@ -1,14 +1,14 @@
 interface TextProps {
   children: React.ReactNode;
   as?: 'div' | 'span' | 'p';
-  classname?: string;
+  className?: string;
 }
 
 const Text = (props: TextProps) => {
   const TextComponent = props.as || 'div';
   return (
     <>
-      <TextComponent className={props.classname}>{props.children}</TextComponent>
+      <TextComponent className={props.className}>{props.children}</TextComponent>
     </>
   );
 };


### PR DESCRIPTION
- Sorting was not implemented, at a glance the API does not seem to support sorting for events, but I think I might be wrong.
- The client side pagination is controlled directly through Pagination through the Datatable (not much has changed here)
- Server side pagination has moved to AdminEventList itself as for now the way pagination works is tightly coupled to the API itself.
- Might be a way to abstract the adminevent list further and make it more reusable, but this might be more trouble than its worth.