### PR TITLE
feat: simple script to help import and convert events markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "husky": "^8.0.3",
         "lint-staged": "^15.0.2",
         "next-translate-plugin": "^2.6.1",
+        "node-html-markdown": "^1.3.0",
         "postcss": "^8.4.31",
         "prettier": "^3.0.3",
         "storybook": "^7.5.1",
@@ -27993,6 +27994,44 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-html-markdown": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-html-markdown/-/node-html-markdown-1.3.0.tgz",
+      "integrity": "sha512-OeFi3QwC/cPjvVKZ114tzzu+YoR+v9UXW5RwSXGUqGb0qCl0DvP406tzdL7SFn8pZrMyzXoisfG2zcuF9+zw4g==",
+      "dev": true,
+      "dependencies": {
+        "node-html-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.11.tgz",
+      "integrity": "sha512-FAgwwZ6h0DSDWxfD0Iq1tsDcBCxdJB1nXpLPPxX8YyVWzbfCjKWEzaynF4gZZ/8hziUmp7ZSaKylcn0iKhufUQ==",
+      "dev": true,
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^15.0.2",
     "next-translate-plugin": "^2.6.1",
+    "node-html-markdown": "^1.3.0",
     "postcss": "^8.4.31",
     "prettier": "^3.0.3",
     "storybook": "^7.5.1",

--- a/src/components/event/EventContent.tsx
+++ b/src/components/event/EventContent.tsx
@@ -13,7 +13,6 @@ const EventContent = ({ event, contentField, heading }: EventContentProps) => {
   if (!event[contentField]) return null;
   return (
     <>
-      <p>fdsfsd</p>
       {heading && <Heading as="h2">{heading}</Heading>}
       {event[contentField] ? compiler(event[contentField]?.toString() ?? '') : null}
     </>

--- a/src/lib/scribo-markdown/README.md
+++ b/src/lib/scribo-markdown/README.md
@@ -1,0 +1,32 @@
+# Scribo markdown editor
+
+Markdown editor built on Lexical framework.
+
+### Example use
+
+```js
+import React, { useState } from 'react';
+import MarkdownEditor from './MarkdownEditor';
+
+function App() {
+  const initialMarkdown = 'Hello **markdown**!';
+  const [markdown, setMarkdown] = useState<string>(initialMarkdown);
+
+  const onChange = (markdown: string) => {
+    setMarkdown(markdown);
+  };
+
+  return (
+    <div className='App'>
+      <h1>Markdown editor</h1>
+      <h2>Make some content</h2>
+      <MarkdownEditor onChange={onChange} initialMarkdown={markdown} />
+      <h2>Markdown output</h2>
+      <pre>{markdown}</pre>
+    </div>
+  );
+}
+
+export default App;
+
+```

--- a/src/utils/automation/event-importer/importer.ts
+++ b/src/utils/automation/event-importer/importer.ts
@@ -1,0 +1,94 @@
+/*
+Update some missing values (such as token) below
+
+Make sure the the url to update to is set correctly, to avoid pushing to production accidentally!
+Then run `npx ts-node ./src/utils/automation/event-importer/importer.ts`
+
+!!!! Warning - currently uploading an event works, but afterwards, since slug must be unique a 409 is thrown.
+This makes it impossible to fix already uploaded items unless we know the actual event id. For dev this is not such
+an issue, as we can just nuke all events before continuing. For production it becomes a little more important
+
+*/
+
+import { EventDto, EventFormDto } from '@losol/eventuras';
+import { NodeHtmlMarkdown } from 'node-html-markdown';
+
+import { apiFetch } from '@/utils/api';
+import Logger from '@/utils/Logger';
+
+/* all markdown fields of event which should be converted */
+const MarkdownFields = {
+  description: '',
+  practicalInformation: '',
+  moreInformation: '',
+  welcomeLetter: '',
+};
+const organizationId = 1;
+/*
+  Manually put access token here
+*/
+const accessToken = null;
+if (!accessToken) throw new Error('No AccessToken');
+const convertMarkdown = (event: EventDto): EventFormDto => {
+  Object.keys(MarkdownFields).forEach((markdownField: string) => {
+    const key = markdownField as keyof typeof MarkdownFields;
+    const markdown = event[key] as string;
+    if (markdown && markdown?.length) {
+      event[key] = NodeHtmlMarkdown.translate(markdown);
+    }
+  });
+  delete event.id;
+  return event as EventFormDto;
+};
+
+const postOrPutUpdate = async (updatedEvent: EventFormDto, eventId?: string) => {
+  /*
+    Where to upload updated events to
+  */
+  let baseUrl = 'https://api.eventuras.losol.io/v3/events';
+  let method = 'POST';
+  if (eventId) {
+    baseUrl = `${baseUrl}/${eventId}`;
+    method = 'PUT';
+  }
+  return await fetch(baseUrl, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json', //default to json
+      'Eventuras-Org-Id': organizationId.toString(),
+    },
+    method,
+    body: JSON.stringify(updatedEvent),
+  }).then(async r => {
+    let res = null;
+    try {
+      res = await r.json();
+    } catch {}
+    try {
+      res = await r.text();
+    } catch {}
+    return res || r;
+  });
+};
+
+const importConvertEventsFromProductionToDev = async () => {
+  /**
+   * If more pages are available, manually change this url (page=2,page=3 etc)
+   */
+  const productionEventEndpoint =
+    'https://api.legekurs.no/v3/events?includePastEvents=true&page=1&count=1';
+  const result = await apiFetch(productionEventEndpoint);
+  if (result.ok) {
+    const events: EventDto[] = result.value.data;
+    for (let i = 0; i < events.length; i++) {
+      const event = events[i];
+      const updatedEvent = convertMarkdown(event);
+      updatedEvent.organizationId = organizationId;
+      const result = await postOrPutUpdate(updatedEvent);
+
+      Logger.info({ namespace: 'importer' }, updatedEvent.slug, result.status, result.statusText);
+    }
+  }
+};
+
+importConvertEventsFromProductionToDev();


### PR DESCRIPTION
I feel like in a way this is not part of the repo conceptually speaking, but it is handy to have these sort of scripts 'close' to source, will expand this with automated event deletion and str-replace on any strings not caught by the markdown converter